### PR TITLE
Update name in package.json to reflect the repo name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cordova-plugin-echoplugin",
+  "name": "cordova-plugin-wefitter",
   "version": "0.0.1",
   "description": "WeFitterHealthKitPlugin",
   "cordova": {
@@ -13,10 +13,7 @@
     "url": "git+https://github.com/gjwdijk/cordova-plugin-wefitter.git"
   },
   "keywords": [
-    "echo",
-    "Notification",
-    "Message",
-    "Alert",
+    "wefitter",
     "ecosystem:cordova",
     "cordova-ios"
   ],


### PR DESCRIPTION
Correctly adds the plugin when running `cordova platform add`